### PR TITLE
Hardware interrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,12 +41,19 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "lazy_static",
+ "pc-keyboard",
  "pic8259",
  "spin",
  "uart_16550",
  "volatile 0.2.6",
  "x86_64",
 ]
+
+[[package]]
+name = "pc-keyboard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6f2d937e3b8d63449b01401e2bae4041bc9dd1129c2e3e0d239407cf6635ac"
 
 [[package]]
 name = "pic8259"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ volatile = "=0.2.6"
 x86_64 = "0.14.2"
 uart_16550 = "0.2.0"
 pic8259 = "0.10.1"
+pc-keyboard = "0.5.0"
 
 [package.metadata.bootimage]
 test-args = [

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -37,7 +37,7 @@ lazy_static! {
             const STACK_SIZE: usize = 4096 * 5;
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 
-            let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
+            let stack_start = VirtAddr::from_ptr(unsafe {&STACK });
             let stack_end = stack_start + STACK_SIZE;
             stack_end
         };

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -10,6 +10,7 @@ use spin;
 #[repr(u8)]
 pub enum InterruptIndex {
     Timer = PIC_1_OFFSET,
+    Keyboard, 
 }
 
 impl From<InterruptIndex> for u8 {
@@ -37,6 +38,7 @@ lazy_static! {
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX); // new
         }
         idt[InterruptIndex::Timer.into()].set_handler_fn(timer_interrupt_handler);
+        idt[InterruptIndex::Keyboard.into()].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }
@@ -76,5 +78,36 @@ pub static PICS: spin::Mutex<ChainedPics> =
         unsafe {
             PICS.lock()
             .notify_end_of_interrupt(InterruptIndex::Timer.into());
+    }
+}
+
+extern "x86-interrupt" fn keyboard_interrupt_handler(
+    _stack_frame: InterruptStackFrame)
+{
+    use pc_keyboard::{layouts,DecodedKey, HandleControl, Keyboard, ScancodeSet1};
+    use spin::Mutex;
+    use x86_64::instructions::port::Port;
+
+    lazy_static! {
+        static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> =
+            Mutex::new(Keyboard::new(layouts::Us104Key, ScancodeSet1, HandleControl::Ignore));
+    }
+
+    let mut keyboard = KEYBOARD.lock();
+    let mut port = Port::new(0x60);
+    
+    let scancode:u8 = unsafe { port.read() };
+    if let Ok(Some(key_event)) = keyboard.add_byte(scancode) {
+        if let Some(key) = keyboard.process_keyevent(key_event) {
+            match key {
+                DecodedKey::Unicode(character) => print!("{}", character),
+                DecodedKey::RawKey(key) => print!("{:?}", key),
+            }
+        }
+    }
+    
+    unsafe {
+        PICS.lock()
+            .notify_end_of_interrupt(InterruptIndex::Keyboard.into());
     }
 }

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,10 +1,28 @@
-use crate::println;
+use crate::{print, println};
 use crate::gdt;
 
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
 use pic8259::ChainedPics;
 use spin;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum InterruptIndex {
+    Timer = PIC_1_OFFSET,
+}
+
+impl From<InterruptIndex> for u8 {
+    fn from(ii: InterruptIndex) -> Self{
+        ii as u8
+    }
+}
+
+impl From<InterruptIndex> for usize {
+    fn from(ii: InterruptIndex) -> Self{
+        ii as usize
+    }
+}
 
 // -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 // IDT
@@ -18,7 +36,7 @@ lazy_static! {
             idt.double_fault.set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX); // new
         }
-
+        idt[InterruptIndex::Timer.into()].set_handler_fn(timer_interrupt_handler);
         idt
     };
 }
@@ -48,5 +66,15 @@ fn test_breakpoint_exception() {
 pub const PIC_1_OFFSET: u8 = 32;
 pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 
-pub static PICs: spin::Mutex<ChainedPics> =
+pub static PICS: spin::Mutex<ChainedPics> =
     spin::Mutex::new(unsafe {ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET)});
+
+    extern "x86-interrupt" fn timer_interrupt_handler(
+        _stack_frame: InterruptStackFrame)
+    {
+        print!(".");
+        unsafe {
+            PICS.lock()
+            .notify_end_of_interrupt(InterruptIndex::Timer.into());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub extern "C" fn _start() -> ! {
 pub fn init() {
     gdt::init();
     interrupts::init_idt();
-    unsafe { interrupts::PICs.lock().initialize()}
+    unsafe { interrupts::PICS.lock().initialize()}
     x86_64::instructions::interrupts::enable();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
     serial_println!("[failed]\n");
     serial_println!("Error: {}\n", info);
     exit_qemu(QemuExitCode::Failed);
-    loop {}
+    
+    hlt_loop();
 }
 
 #[cfg(test)]
@@ -47,7 +48,7 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
 pub extern "C" fn _start() -> ! {
     init();
     test_main();
-    loop {}
+    hlt_loop();
 }
 
 pub fn init() {
@@ -76,5 +77,11 @@ pub fn exit_qemu(exit_code: QemuExitCode) {
     unsafe {
         let mut port = Port::new(0xf4);
         port.write(exit_code as u32);
+    }
+}
+
+pub fn hlt_loop() ->! {
+    loop {
+        x86_64::instructions::hlt();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,12 @@ pub extern "C" fn _start() -> ! {
 
     println!("It did not crash!");
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+    //#[allow(clippy::empty_loop)]
+    loop {
+        use orust_os::print;
+        print!("-");
+        for _ in 0..10000{}
+    }
 }
 
 #[cfg(not(test))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,19 +22,14 @@ pub extern "C" fn _start() -> ! {
 
     println!("It did not crash!");
 
-    //#[allow(clippy::empty_loop)]
-    loop {
-        use orust_os::print;
-        print!("-");
-        for _ in 0..10000{}
-    }
+    orust_os::hlt_loop();
 }
 
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     println!("{info}");
-    loop {}
+    orust_os::hlt_loop()
 }
 
 #[cfg(test)]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -13,10 +13,14 @@ lazy_static! {
 #[doc(hidden)]
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
-    SERIAL1
-    .lock()
-    .write_fmt(args)
-    .expect("Printing to serial failed");
+    use x86_64::instructions::interrupts;
+
+    interrupts::without_interrupts(|| {
+        SERIAL1
+             .lock()
+             .write_fmt(args)
+             .expect("Printing to serial failed");
+   });
 }
 
 #[macro_export]

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -137,7 +137,11 @@ macro_rules! println {
 
 #[doc(hidden)]
 pub fn _print(args: Arguments) {
-    WRITER.lock().write_fmt(args).unwrap();
+    use x86_64::instructions::interrupts;
+
+    interrupts::without_interrupts(|| {
+        WRITER.lock().write_fmt(args).unwrap();
+    });
 }
 
 #[test_case]
@@ -154,10 +158,15 @@ fn test_println_many() {
 
 #[test_case]
 fn test_println_output() {
+    use x86_64::instructions::interrupts;
+
     let s = "Some test string that fits on a single line";
-    println!("{s}");
-    for (i, c) in s.chars().enumerate() {
-        let screen_char = WRITER.lock().buffer.chars[BUFFER_HEIGHT - 2][i].read();
-        assert_eq!(char::from(screen_char.ascii_character), c);
-    }
+    interrupts::without_interrupts(|| {
+        let mut writer = WRITER.lock();
+        writeln!(writer, "\n{s}").expect("writeln failed");
+        for (i, c) in s.chars().enumerate() {
+            let screen_char = writer.buffer.chars[BUFFER_HEIGHT - 2][i].read();
+            assert_eq!(char::from(screen_char.ascii_character), c);
+        }
+    });
 }


### PR DESCRIPTION
1. Printing (-) without deadlock, and fixing a data race in the output test.
2. Added a halt loop to save CPU cycles, and added a keyboard handler